### PR TITLE
Allow disabling certain whitespace replacements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,25 @@ Removes all whitespace in htmlbars templates.
 ```
 npm install ember-cli-htmlbars-minifier --save-dev
 ```
+
+## Configuration
+
+
+You can choose not to remove certain kinds of whitespace using config options that you can add to your `ember-cli-build.js`. If not specified, they *default* to **true.**
+
+```
+"ember-cli-htmlbars-minifier": {
+    stripIndentation:       true,
+    removeTrailingSpaces:   true,
+    removeSpacesAroundTags: true,
+    stripNewlines:          true,
+    coalesceSpaces:         true
+}
+```
+Config Option | Description |
+--- | --- |
+|stripIndentation        | Remove any consecutive sets of tabs or spaces from the beginning of each line.
+|removeTrailingSpaces    | Remove any whitespace that may be at the end of each line.
+|removeSpacesAroundTags  | Remove any whitespace that occurs before or after an HTML tag or Handlebars tag 
+|stripNewlines           | Remove all newlines from the template (except those that are inside an open tag, which will be ignored by the HTMLBars/Glimmer parser anyway).
+|coalesceSpaces          | Replace any runs of multiple whitespaces with a single space. 

--- a/htmlbars-minifier.js
+++ b/htmlbars-minifier.js
@@ -64,7 +64,8 @@ HtmlbarsMinifier.prototype.processString = function (str) {
             //      foo{{/block}}" => "{{#block}}foo{{/block}}"
             //   - "{{helper}}
             //      foo" => "{{helper}}foo"
-            .replace(/(}}\s*)[\r\n]+/g, '$1')
+            //  This should ignore newlines inside of an opening or self-closing tag
+            .replace(/(}}\s*)[\r\n]+(?![^<]*>)/g, '$1')
 
             // Replaces:
             //   - "<div>foo
@@ -78,7 +79,8 @@ HtmlbarsMinifier.prototype.processString = function (str) {
             //      {{/block}}" => "{{#block}}foo{{/block}}"
             //   - "foo
             //      {{helper}}" => "foo{{helper}}"
-            .replace(/[\r\n]+(\s*{{)/g, '$1')
+            //  This should ignore newlines inside of an opening or self-closing tag
+            .replace(/(?![^<]*>)[\r\n]+(\s*{{)/g, '$1')
     }
 
     if (this.options.coalesceSpaces){

--- a/htmlbars-minifier.js
+++ b/htmlbars-minifier.js
@@ -58,6 +58,35 @@ HtmlbarsMinifier.prototype.processString = function (str) {
         str = str.replace(/\s+$/, '');
     }
 
+    if (this.options.stripNewlines){
+        str = str
+            // Replaces:
+            //   - "<div>
+            //      foo</div>" => "<div>foo</div>"
+            .replace(/(>\s*)[\r\n]+/g, '$1')
+
+            // Replaces:
+            //   - "{{#block}}
+            //      foo{{/block}}" => "{{#block}}foo{{/block}}"
+            //   - "{{helper}}
+            //      foo" => "{{helper}}foo"
+            .replace(/(}}\s*)[\r\n]+/g, '$1')
+
+            // Replaces:
+            //   - "<div>foo
+            //      </div>" => "<div>foo</div>"
+            //   - "foo
+            //      </br>" => "foo</br>"
+            .replace(/[\r\n]+(\s*<)/g, '$1')
+
+            // Replaces:
+            //   - "{{#block}}foo
+            //      {{/block}}" => "{{#block}}foo{{/block}}"
+            //   - "foo
+            //      {{helper}}" => "foo{{helper}}"
+            .replace(/[\r\n]+(\s*{{)/g, '$1')
+    }
+
     return str;
 };
 

--- a/htmlbars-minifier.js
+++ b/htmlbars-minifier.js
@@ -16,6 +16,18 @@ HtmlbarsMinifier.prototype.constructor = HtmlbarsMinifier;
 HtmlbarsMinifier.prototype.extensions = ['hbs'];
 HtmlbarsMinifier.prototype.targetExtension = 'hbs';
 HtmlbarsMinifier.prototype.processString = function (str) {
+    if (this.options.stripIndentation){
+        // Replaces:
+        //   - "     foo" => "foo"
+        str = str.replace(/^(\t|\s)+/mg, '');
+    }
+
+    if (this.options.removeTrailingSpaces){
+        // Replaces:
+        //   - "foo     " => "foo"
+        str = str.replace(/\s+$/mg, '');
+    }
+
     if (this.options.removeSpacesAroundTags){
         str = str
             // Replaces:
@@ -38,24 +50,6 @@ HtmlbarsMinifier.prototype.processString = function (str) {
             // Replaces:
             //   - ">      {{" => ">{{"
             .replace(/>\s+{{/g, '>{{')
-    }
-
-    if (this.options.coalesceSpaces){
-        // Replaces:
-        //   - ">           foo" => "> foo"
-        str = str.replace(/\s{2,}/g, ' ');
-    }
-
-    if (this.options.stripIndentation){
-        // Replaces:
-        //   - "     foo" => "foo"
-        str = str.replace(/^\s+/mg, '');
-    }
-
-    if (this.options.removeTrailingSpaces){
-        // Replaces:
-        //   - "foo     " => "foo"
-        str = str.replace(/\s+$/mg, '');
     }
 
     if (this.options.stripNewlines){
@@ -85,6 +79,12 @@ HtmlbarsMinifier.prototype.processString = function (str) {
             //   - "foo
             //      {{helper}}" => "foo{{helper}}"
             .replace(/[\r\n]+(\s*{{)/g, '$1')
+    }
+
+    if (this.options.coalesceSpaces){
+        // Replaces:
+        //   - ">           foo" => "> foo"
+        str = str.replace(/\s{2,}/g, ' ');
     }
 
     return str;

--- a/htmlbars-minifier.js
+++ b/htmlbars-minifier.js
@@ -49,13 +49,13 @@ HtmlbarsMinifier.prototype.processString = function (str) {
     if (this.options.stripIndentation){
         // Replaces:
         //   - "     foo" => "foo"
-        str = str.replace(/^\s+/, '');
+        str = str.replace(/^\s+/mg, '');
     }
 
     if (this.options.removeTrailingSpaces){
         // Replaces:
         //   - "foo     " => "foo"
-        str = str.replace(/\s+$/, '');
+        str = str.replace(/\s+$/mg, '');
     }
 
     if (this.options.stripNewlines){

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = {
             removeTrailingSpaces: true,
             coalesceSpaces: true,
             removeSpacesAroundTags: true,
+            stripNewlines: true,
         };
 
         this.options = appOptions["ember-cli-htmlbars-minifier"] || {};

--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ module.exports = {
 
     initializeOptions: function(appOptions) {
         var defaultOptions = {
+            stripIndentation: true,
+            removeTrailingSpaces: true,
+            coalesceSpaces: true,
+            removeSpacesAroundTags: true,
         };
 
         this.options = appOptions["ember-cli-htmlbars-minifier"] || {};

--- a/index.js
+++ b/index.js
@@ -3,12 +3,29 @@ var HtmlbarsMinifier = require('./htmlbars-minifier');
 module.exports = {
     name: 'ember-cli-htmlbars-minifier',
 
+    initializeOptions: function(appOptions) {
+        var defaultOptions = {
+        };
+
+        this.options = appOptions["ember-cli-htmlbars-minifier"] || {};
+        for (var option in defaultOptions) {
+            if (!this.options.hasOwnProperty(option)) {
+                this.options[option] = defaultOptions[option];
+            }
+        }
+    },
+    included: function(app) {
+        this._super.included.apply(this, arguments);
+
+        this.initializeOptions(app.options);
+    },
     setupPreprocessorRegistry: function(type, registry) {
+        let self = this;
         registry.add('template', {
             name: 'ember-cli-htmlbars-minifier',
             ext: 'hbs',
             toTree: function(tree) {
-                return HtmlbarsMinifier(tree);
+                return HtmlbarsMinifier(tree, self.options);
             }
         });
     }


### PR DESCRIPTION
This gives the user finer control over what whitespace is replaced.

Additionally, this adds missing multiline and global flags to the regexes that remove leading and trailing whitespace.